### PR TITLE
Fix incorrect licensing declaration in the project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 > 下載檔案請參考 `input/pagecontent/downloads.md` 
 ## 授權
 
-MIT License  
 本專案授權詳見 [LICENSE](LICENSE)。
 
 ## 參考連結


### PR DESCRIPTION
This is an MIT-based custom license with [additional restrictive, retaliatory terms against certain individuals and entities](https://github.com/ITRI-BDL-D/MOHW_TWCoreIG/blob/2b0434215669d7afba9c95b7bc45e84dc3c91585/LICENSE#L23-L34), declaring it as "MIT License" is a violation of the MIT License.

![Screenshot](https://github.com/user-attachments/assets/2a34c853-f8fa-40f2-b508-7f559dff0fb3)
